### PR TITLE
AfterLabs: Allow to Show 6G Icon Instead 4G & 5G [2/2]

### DIFF
--- a/res/values/afterlife_strings.xml
+++ b/res/values/afterlife_strings.xml
@@ -214,6 +214,10 @@
     <!-- 5G icon -->
     <string name="show_fiveg_icon_summary">Show 5G instead of LTE &amp; 4G</string>
     <string name="show_fiveg_icon_title">Display 5G Indicator</string>
+
+    <!-- 6G icon -->
+    <string name="show_sixg_icon_summary">Show 6G instead of LTE &amp; 4G &amp; 5G</string>
+    <string name="show_sixg_icon_title">Display 6G Indicator</string>
     
     <!-- Data disabled icon -->
     <string name="data_disabled_icon_title">Show data disabled icon</string>

--- a/res/xml/category_statusbar.xml
+++ b/res/xml/category_statusbar.xml
@@ -92,6 +92,12 @@
         android:summary="@string/show_fiveg_icon_summary"
         android:defaultValue="false" />
 
+    <com.afterlife.support.preference.SystemSettingSwitchPreference
+        android:key="show_sixg_icon"
+        android:title="@string/show_sixg_icon_title"
+        android:summary="@string/show_sixg_icon_summary"
+        android:defaultValue="false" />
+
      <com.afterlife.support.preference.SystemSettingSwitchPreference 
         android:key="use_old_mobiletype" 
         android:title="@string/use_old_mobiletype_title" 


### PR DESCRIPTION
Credits: https://t.me/cool_modules for 6G icons

Authored-by: Ari Lesmana <kingarijk66@gmail.com>